### PR TITLE
Add 'optimist' and 'watcher_lib' as dependencies to package.json for easier NPM installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,12 @@
     "bin": {
         "less-watcher":      "./bin/less-watcher"
     },
+
+    "dependencies" : {
+        "watcher_lib":     "latest",
+        "optimist":        "latest"
+    },
+
     "devDependencies": {
       "coffee-script": "latest"
     }


### PR DESCRIPTION
This is exactly what I was looking for, however I didn't have 'optimist' and 'watcher_lib' installed before I installed this module via NPM. I had to install those manually after seeing NPM kick out error messages for those missing modules. This pull request should enable a 1-line install.
